### PR TITLE
Allow an entire namespace of events to be removed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ jQuery API.
 
 ###What Cash Is
 A tiny library that absracts some pain points when working with native Javascript
-and DOM. 
+and DOM.
 
 ####Why?
 Because if you are not supporting bad browsers you do not need the shims that
@@ -21,13 +21,13 @@ now, **cash** thinks you should use those.
 
     // as an example, you have a nodeList
     var things = document.querySelectorAll('.foo');
-    
+
 Passing the `things` nodeList as an arg to `$()` would result in **cash** storing
 that list on the **cash** object as `q`, and here's the important part, **as an array**.
 
     $(things);
     // now there is a this.q that is an array of DOM elements with a class of foo
-    
+
 In a familar fashion, calling `$()` will return `$` itself so that chainable stuff
 can happen. In an unfamiliar fashion however, what is returned **is not a unique instance**.
 This is paramount to understand. Any call to `$()` simply sets the `q` and returns.
@@ -39,12 +39,12 @@ That means that there are 3 elements in the `$.q`.
     $(things);
     $.q //=> [div, div, div]
     Array.isArray($.q); //=> true
-    
-Since calling `$()` returns `$` though the `q` array is always available in a 
+
+Since calling `$()` returns `$` though the `q` array is always available in a
 chainable fashion, ready to be used.
 
     $(things).q.forEach(function(el) {el.classList.remove('foo');})
-    
+
 **NOTE**: Calling $(...) resets the `q` to what you pass in. Sometimes you may
 want to re-use an existing `q`, but that's not the preferred pattern. All chainable methods
 operate on, and possibly modify the `q`, **including event callbacks**.
@@ -54,14 +54,14 @@ It's not expensive to call `$()` so don't fear to simply reset the `q`.
 ###Why You No Pass In String?
 It would not be expensive or bloat the codebase to allow `$()` to take a string then
 perform a querySelectorAll with it, returning that back to `$()`. But I won't. Why?
-One, it promotes `God Dollar` and that's bad. An 'unscoped' call to `$` is a 
-**code smell** and should be rather unwieldy. Two, it's a slippery slope for the 
-dollar function to start accepting other args. It accepts a node or a collection 
+One, it promotes `God Dollar` and that's bad. An 'unscoped' call to `$` is a
+**code smell** and should be rather unwieldy. Two, it's a slippery slope for the
+dollar function to start accepting other args. It accepts a node or a collection
 of them and that's all.
 
 ##Chainable Methods
 Some jQuery-type methods are still needed, which ones will be an ongoing debate
-that is part of the future development of **cash**. 
+that is part of the future development of **cash**.
 
 ###Events
 The familiar `on` and `off` methods are provided as, though event binding is standardized
@@ -74,43 +74,51 @@ method with the exception of the order of arguments:
 
 + **event** A DOM Event name
 + **callback** A function to be called when the event occurs
-+ **selector** Optional CSS selector allowing delegatation of events to the target element
++ **selector** Optional CSS selector allowing delegatation of events to the target element.
 + **data** Optional object literal passed to the callback as `e.data`
 
+All events bound by cash will have a delegateTarget attribute. If a selector was used
+the delegateTarget will match the provided selector.
+
 ####off(event[, callback])
-Removes all events bound to the `event` name, or just the passed in `callback` 
+Removes all events bound to the `event` name, or just the passed in `callback`
 (if present), for each element in the `q`. Maintaining the correct reference to
 a `callback` can be ugly so if you are looking to remove a specific `callback` on
 an element for an event which may have many listeners, using a `namespaced event`
 may be a better choice.
+
+You may use a `*` event name to capture sets of events. For instance, `*.ns` would
+remove all events which were bound to the `ns` namespace. Similarly `*` would
+remove all events, regardless of event name or namespace.
 
 #####Event Namespacing
 Similar in practice to the jQuery event namespace, you can append a value to an
 event name (or many of them) as a dot-delimited string:
 
     $(things).on('click.foo', callback);
-    
+
 This makes it much simpler to remove a specific callback, say another click event
 listener had already been added:
 
     $(things).on('click', anotherCallback);
-    
-Simply removing `click` from `things` via `off` would remove both listeners. In a 
+
+Simply removing `click` from `things` via `off` would remove both listeners. In a
 case where you only wanted to remove `callback` and not `anotherCallback` you would
 pass the namespaced event name to `off`:
 
     $(things).off('click.foo');
-    
+
 There is no need to pass the second argument.
+
 
 ######Caveat
 Cash does not override the native event passed to your listeners. This means that
 the `trigger` method cannot be used to fire **only** a namespaced event.
 
     $(things).on('click', callback).on('click.foo', fooCallback);
-    
+
 Calling `trigger('click')` on `things` here would call both `callback` and `fooCallback`.
 The latter would recieve the namespace attached to the event passed to it however, as
-`event.namespace` (it would be 'foo'). The former would not, `event.namespace` would be 
+`event.namespace` (it would be 'foo'). The former would not, `event.namespace` would be
 falsey.
 

--- a/spec/event.spec.js
+++ b/spec/event.spec.js
@@ -28,7 +28,7 @@ afterEach(function() {
   tt.innerHTML = '';
 
   // make sure to clean up bound events
-  $(tt).off('click').off('change');
+  $(tt).off('*');
 });
 
 describe('cash event binding', function() {

--- a/src/cash.js
+++ b/src/cash.js
@@ -245,6 +245,13 @@
     // Empty function
     cash.noop = function() {},
     // ###off
+    // Remove event bindings from the q which match the given type and/or function.
+    // By supplying "*.yourNamespace" as the event type, you can remove all events
+    // in a namespace.
+    //
+    // `param` {string} `type`. An event trigger, can be namespaced
+    // `param` {function}  `fn`. The function which should be removed, optional.
+    // `returns` cash
     cash.off = function(type, fn) {
       var sp = type.split('.'), ev = sp[0], ns = sp.splice(1).join('.'),
         events, cid;


### PR DESCRIPTION
Also fixed the `targ` reference in `$.on()`. It was causing the incorrect delegateTarget to be set. Oh, and on that note -- switched currentTarget to delegateTarget.
