### PR TITLE
[MAYBE: 1 of 2] use data-cid vs cid as it needs to be an attr (see cache-cln-2 for the other)

### DIFF
--- a/spec/core.spec.js
+++ b/spec/core.spec.js
@@ -39,11 +39,6 @@ describe('Core', function() {
     expect($.q).toBe(ary);
   });
   
-  it('can create an element with class and id', function() {
-    expect($.q[0].id).toBe('foo');
-    expect($.q[0].classList.contains('bar')).toBe(true);
-  });
-  
   it('fetches various from the q via get', function() {
     expect(Array.isArray($.find('li').get())).toBe(true);
     expect($.get(0).id).toBe('one');  

--- a/spec/event.spec.js
+++ b/spec/event.spec.js
@@ -40,7 +40,7 @@ describe('Event', function() {
 
   it('records the bound event in the cache', function() {
     $(document.querySelector('#testTarget')).on('click', window.callBack);
-    expect($.cache.events[$.q[0].cid]).toBeTruthy();
+    expect($.cache.events[$.q[0].getAttribute('data-cid')]).toBeTruthy();
     $(document.querySelector('#testTarget')).off('click');
   });
 
@@ -168,7 +168,7 @@ describe('Event', function() {
     window.meSecond = function(e) {ary.push('bubble');};
     
     $(tt).on('click', window.meFirst, null, null, true).on('click', window.meSecond);
-    expect($.cache.events[tt.cid].click[0].cap).toBe(true);
+    expect($.cache.events[tt.getAttribute('data-cid')].click[0].cap).toBe(true);
     $.trigger('click');
     expect(ary[0]).toBe('capture');
     expect(ary[1]).toBe('bubble');
@@ -197,8 +197,8 @@ describe('Event', function() {
     var tt = document.querySelector('#testTarget');
     tt.innerHTML = '<div><input type="text" name="one"></input><input type="text" name="two"></input></div>';
     $(tt).on('focus', window.handleFocus, 'input[name="two"]').on('blur', window.handleBlur, 'input[name="two"]');
-    expect($.cache.events[tt.cid].focus[0].cap).toBe(true);
-    expect($.cache.events[tt.cid].blur[0].cap).toBe(true);
+    expect($.cache.events[tt.getAttribute('data-cid')].focus[0].cap).toBe(true);
+    expect($.cache.events[tt.getAttribute('data-cid')].blur[0].cap).toBe(true);
     $(tt).find('input[name="two"]').trigger('focus');
     expect(window.focused).toBe(1);
     expect(window.whoCalled).toBe('two');

--- a/spec/hide.spec.js
+++ b/spec/hide.spec.js
@@ -19,7 +19,7 @@ describe('Hide', function () {
 
     expect(getComputedStyle(el).display).toBe('none');
     expect(el.style.display).toBe('none');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
 
   it('hides an element with inline "display"', function() {
@@ -37,7 +37,7 @@ describe('Hide', function () {
 
     expect(getComputedStyle(el).display).toEqual('none');
     expect(el.style.display).toEqual('none');
-    expect($.cache.display[el.cid]).toBe('block');
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe('block');
   });
 
   it('hides an element with inline "display: none"', function() {
@@ -55,7 +55,7 @@ describe('Hide', function () {
 
     expect(getComputedStyle(el).display).toEqual('none');
     expect(el.style.display).toBe('none');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
 
   it('hides an element with css "display"', function() {
@@ -76,7 +76,7 @@ describe('Hide', function () {
 
     expect(getComputedStyle(el).display).toEqual('none');
     expect(el.style.display).toEqual('none');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
 
   it('hides an element with css "display: none"', function() {
@@ -97,7 +97,7 @@ describe('Hide', function () {
 
     expect(getComputedStyle(el).display).toEqual('none');
     expect(el.style.display).toEqual('');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
 
   it('hides an element with inline "display" and css "display: none"', function() {
@@ -118,7 +118,7 @@ describe('Hide', function () {
 
     expect(getComputedStyle(el).display).toEqual('none');
     expect(el.style.display).toEqual('none');
-    expect($.cache.display[el.cid]).toEqual('block');
+    expect($.cache.display[el.getAttribute('data-cid')]).toEqual('block');
   });
 
   it('hides an element with inline "display: none" and css "display"', function() {
@@ -139,6 +139,6 @@ describe('Hide', function () {
 
     expect(getComputedStyle(el).display).toEqual('none');
     expect(el.style.display).toEqual('none');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
   });

--- a/spec/manipulation.spec.js
+++ b/spec/manipulation.spec.js
@@ -1,18 +1,37 @@
 describe('Manipulation', function() {
-  
   beforeEach(function() {
-    $.create('<div id="foo" class="bar"></div>').get(0).innerHTML =
-      '<div id="baz"><ul><li id="one"></li><li id="two"></li></ul></div><div id="qux"><ul><li id="three"></li><li class="me"></li></ul></div>';
+    document.querySelector('#testTarget').innerHTML = '<div id="testTargetChildA"><div id="testTargetChildB" /></div>';
+    $(document.querySelector('#testTargetChildA')).on('click', $.noop);
+    $(document.querySelector('#testTargetChildB')).on('click', $.noop);
+
   });
 
-  it('removes cache entries for an element removed with remove', function() {
-    var div = $.q[0];
-    expect($(div).find('li').q.length).toBe(4);
-    $(div).find('li.me').on('click', $.noop);
-    expect($.cache.events[$.q[0].cid]).toBeTruthy();
-    $(div).find('li.me').remove();
-    expect($(div).find('li').q.length).toBe(3);
-    expect($.cache.events[$.q[0].cid]).toBeFalsy();
+  it('cleans up the cache for the element and its children', function() {
+    var parent = document.querySelector('#testTargetChildA'),
+        child  = document.querySelector('#testTargetChildB');
+
+    expect(parent.getAttribute('data-cid')).toBeTruthy();
+
+    expect(child.getAttribute('data-cid')).toBeTruthy();
+
+    expect(Object.keys($.cache.events[parent.getAttribute('data-cid')]).length).toBe(1);
+    expect(Object.keys($.cache.events[child.getAttribute('data-cid')]).length).toBe(1);
+
+    $(parent).remove();
+
+    expect($.cache.events[parent.getAttribute('data-cid')]).toBeFalsy();
+    expect($.cache.events[child.getAttribute('data-cid')]).toBeFalsy();
+  });
+
+  it('removes the element from the dom', function() {
+    var parent = document.querySelector('#testTargetChildA');
+    $(parent).remove();
+    expect(parent.parentNode).toBeFalsy();
   });
   
+  it('can create an element with class and id', function() {
+    $.create('<div id="foo" class="bar"></div>');
+    expect($.q[0].id).toBe('foo');
+    expect($.q[0].classList.contains('bar')).toBe(true);
+  });
 });

--- a/spec/show.spec.js
+++ b/spec/show.spec.js
@@ -18,7 +18,7 @@ describe('Show', function () {
 
     expect(getComputedStyle(el).display).toBe('inline');
     expect(el.style.display).toBe('');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
 
   it('shows an element with inline "display"', function() {
@@ -36,7 +36,7 @@ describe('Show', function () {
 
     expect(getComputedStyle(el).display).toEqual('block');
     expect(el.style.display).toEqual('block');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
 
   it('shows an element with inline "display: none"', function() {
@@ -54,7 +54,7 @@ describe('Show', function () {
 
     expect(getComputedStyle(el).display).toEqual('inline');
     expect(el.style.display).toBe('');
-    expect($.cache.display[el.cid]).toEqual('none');
+    expect($.cache.display[el.getAttribute('data-cid')]).toEqual('none');
   });
 
   it('shows an element with css "display"', function() {
@@ -75,7 +75,7 @@ describe('Show', function () {
 
     expect(getComputedStyle(el).display).toEqual('block');
     expect(el.style.display).toEqual('');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
 
   it('shows a node with css "display: none"', function() {
@@ -96,7 +96,7 @@ describe('Show', function () {
 
     expect(getComputedStyle(el).display).toEqual('block');
     expect(el.style.display).toEqual('block');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
 
   it('shows an element with inline "display" and css "display: none"', function() {
@@ -117,7 +117,7 @@ describe('Show', function () {
 
     expect(getComputedStyle(el).display).toEqual('block');
     expect(el.style.display).toEqual('block');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
 
   it('shows an element with inline "display: none" and css "display"', function() {
@@ -138,6 +138,6 @@ describe('Show', function () {
 
     expect(getComputedStyle(el).display).toEqual('block');
     expect(el.style.display).toEqual('');
-    expect($.cache.display[el.cid]).toBe('none');
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe('none');
   });
 });

--- a/spec/toggle.spec.js
+++ b/spec/toggle.spec.js
@@ -19,13 +19,13 @@ describe('Toggle', function() {
 
     expect(getComputedStyle(el).display).toEqual('none');
     expect(el.style.display).toEqual('none');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
 
     $(el).toggle();
 
     expect(getComputedStyle(el).display).toEqual('inline');
     expect(el.style.display).toEqual('');
-    expect($.cache.display[el.cid]).toBe('none');
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe('none');
   });
 
   it('toggles correctly with inline "display: none"', function() {
@@ -43,13 +43,13 @@ describe('Toggle', function() {
 
     expect(getComputedStyle(el).display).toEqual('inline');
     expect(el.style.display).toEqual('');
-    expect($.cache.display[el.cid]).toBe('none');
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe('none');
 
     $(el).toggle();
 
     expect(getComputedStyle(el).display).toEqual('none');
     expect(el.style.display).toEqual('none');
-    expect($.cache.display[el.cid]).toBe(undefined);
+    expect($.cache.display[el.getAttribute('data-cid')]).toBe(undefined);
   });
   
   it('toggles correctly with both', function() {
@@ -70,11 +70,11 @@ describe('Toggle', function() {
 
     expect(getComputedStyle(els[0]).display).toEqual('inline');
     expect(els[0].style.display).toEqual('');
-    expect($.cache.display[els[0].cid]).toBe('none');
+    expect($.cache.display[els[0].getAttribute('data-cid')]).toBe('none');
     
     expect(getComputedStyle(els[1]).display).toEqual('none');
     expect(els[1].style.display).toEqual('none');
-    expect($.cache.display[els[1].cid]).toBe(undefined);
+    expect($.cache.display[els[1].getAttribute('data-cid')]).toBe(undefined);
 
   });
 });

--- a/src/cash.js
+++ b/src/cash.js
@@ -4,7 +4,16 @@
 // Hash that holds the event and display data
 cash.cache = {events: {}, display: {}};
 // generate a unique id for elements
-cash.cid = 0;
+cash._cid_ = 0;
+// ###_clearCache_
+// Clean up the cache for the given el.
+//
+// `param` {Element} `el`
+// `returns` el
+cash._unsetCache_ = function(el) {
+  delete this.cache.events[el.getAttribute('data-cid')];
+  return el;
+};
 // ###get
 // Return the entire `q` or a particular element located at an index by 
 // passing nothing or a number respectively. Note that you can pass a 
@@ -44,9 +53,9 @@ cash.noop = function() {},
 // ###setCache
 // private.
 cash._setCache_ = function(ref, el) {
-  var cid = isWindow(el) ? 'window' : el.cid,
+  var cid = isWindow(el) ? 'window' : el.getAttribute('data-cid'),
     obj = this.cache[ref];
-  if(!cid) el.cid = cid = String(++this.cid);
+  if(!cid) {cid = String(++this._cid_); el.setAttribute('data-cid', cid);}
   obj[cid] || (obj[cid] = ref === 'events' ? {} : undefined);
   return obj;
 };

--- a/src/events.js
+++ b/src/events.js
@@ -17,7 +17,7 @@ cash.off = function(type, fn, cap) {
   var sp = type.split('.'), ev = sp[0], ns = sp.splice(1).join('.'),
     all = ev === '*', events, cid;
   this.q.forEach(function(el) {
-    cid = isWindow(el) ? 'window' : el.cid, events = $.cache.events[cid];
+    cid = isWindow(el) ? 'window' : el.getAttribute('data-cid'), events = $.cache.events[cid];
     if(events) {
       (all ? Object.keys(events) : [ev]).forEach(function(k) {
         events[k] && events[k].forEach(function(obj, i, ary) {
@@ -55,7 +55,7 @@ cash.on = function(type, fn, sel, data, cap) {
   // we force capture phase here so that delegation works
   if(!cap && (ev === 'focus' || ev === 'blur') && sel) cap = true;
   this.q.forEach(function(el) {
-    events = $._setCache_('events', el)[el.cid || 'window'];
+    events = $._setCache_('events', el)[el.getAttribute('data-cid') || 'window'];
     events[ev] || (events[ev] = []);
     cb = function(e) {
       var targ;

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -16,9 +16,13 @@ cash.create = function(str) {
 //
 // `returns` cash
 cash.remove = function() {
+  var nodes, i;
   this.q.forEach(function(el) {
-    // not concerned with the display hash
-    delete $.cache.events[el.cid];
+    // child references must be removed first
+    nodes = el.querySelectorAll('[data-cid]');
+    for(i=0; i<nodes.length; i++) $._unsetCache_(nodes[i]);
+    // now the parent
+    $._unsetCache_(el);
     el.parentNode && el.parentNode.removeChild(el);
   });
   return this;

--- a/src/showHide.js
+++ b/src/showHide.js
@@ -22,19 +22,19 @@ cash._sh_ = function(key) {
   function notNone(arg) {return isShow ? arg === 'none': arg !== 'none';}
 
   this.q.forEach(function(el) {
-    var display = $._setCache_('display', el),
-      old = display[el.cid];
+    var display = $._setCache_('display', el), cid = el.getAttribute('data-cid'),
+      old = display[cid];
     if(state(el)) {
-      if(none(old)) delete display[el.cid];
+      if(none(old)) delete display[cid];
     // does an old display value exist?
-    } else if (old && none(old)) {
+    } else if(old && none(old)) {
       el.style.display = old;
-      delete display[el.cid];
+      delete display[cid];
     // the element is not visible and does not have an old display value
     } else {
       // is the element hidden with inline styling?
       if(el.style.display && notNone(el.style.display)) {
-        display[el.cid] = el.style.display;
+        display[cid] = el.style.display;
         el.style.display = isShow ? '' : 'none';
       // the element is hidden through css
       } else el.style.display = isShow ? 'block': 'none';


### PR DESCRIPTION
This is one of two PRs for the same issue. cid's of children of a parent that is being `remove()` d need to be unset from the .cache.events as well. 

This PR takes the 'larger' approach of using 'data-cid' set as an attribute so that it can be queried from the parent as context (then removed)

pros: data-cid is formalized and may be useful in other ways
cons: more code. overhead of getting and setting that attribute
